### PR TITLE
Update Groovy Version and Include Swing?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<groovy.version>2.5.8</groovy.version>
-		<groovy-dateutil.version>2.5.8</groovy-dateutil.version>
+		<groovy-dateutil.version>${groovy.version}</groovy-dateutil.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
 		<groovy-templates.version>${groovy.version}</groovy-templates.version>
 		<groovy-swing.version>${groovy.version}</groovy-swing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
-		<groovy.version>2.5.1</groovy.version>
+		<groovy.version>2.5.8</groovy.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
 		<groovy-templates.version>${groovy.version}</groovy-templates.version>
 		<groovy-xml.version>${groovy.version}</groovy-xml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<ivy.version>2.4.0</ivy.version>
 		<gpars.version>1.2.1</gpars.version>
 		<groovy-swing.version>2.5.8</groovy-swing.version>
+		<groovy-dateutil.version>2.5.8</groovy-dateutil.version>
 	</properties>
 
 	<dependencies>
@@ -154,9 +155,15 @@ Wisconsin-Madison.</license.copyrightOwners>
 		</dependency>
 		<dependency>
 			<!-- NB: Simple UI Building in scripts. -->
-			 <groupId>org.codehaus.groovy</groupId>
+			<groupId>org.codehaus.groovy</groupId>
   			<artifactId>groovy-swing</artifactId>
 			<version>${groovy-swing.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-dateutil</artifactId>
+			<version>${groovy-dateutil.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>scripting-groovy</artifactId>
-	<version>0.2.9-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 
 	<name>SciJava Scripting: Groovy</name>
 	<description>JSR-223-compliant Groovy scripting language plugin.</description>
@@ -95,12 +95,13 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
-		<groovy.version>2.4.8</groovy.version>
+		<groovy.version>2.5.1</groovy.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
 		<groovy-templates.version>${groovy.version}</groovy-templates.version>
 		<groovy-xml.version>${groovy.version}</groovy-xml.version>
 		<ivy.version>2.4.0</ivy.version>
 		<gpars.version>1.2.1</gpars.version>
+		<groovy-swing.version>2.5.8</groovy-swing.version>
 	</properties>
 
 	<dependencies>
@@ -149,6 +150,13 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.codehaus.gpars</groupId>
 			<artifactId>gpars</artifactId>
 			<version>${gpars.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<!-- NB: Simple UI Building in scripts. -->
+			 <groupId>org.codehaus.groovy</groupId>
+  			<artifactId>groovy-swing</artifactId>
+			<version>${groovy-swing.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<groovy-dateutil.version>2.5.8</groovy-dateutil.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
 		<groovy-templates.version>${groovy.version}</groovy-templates.version>
-		<groovy-swing.version>2.5.8</groovy-swing.version>
+		<groovy-swing.version>${groovy.version}</groovy-swing.version>
 		<groovy-xml.version>${groovy.version}</groovy-xml.version>
 		<ivy.version>2.4.0</ivy.version>
 		<gpars.version>1.2.1</gpars.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<groovy.version>2.5.8</groovy.version>
 		<groovy-dateutil.version>${groovy.version}</groovy-dateutil.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
-		<groovy-templates.version>${groovy.version}</groovy-templates.version>
 		<groovy-swing.version>${groovy.version}</groovy-swing.version>
+		<groovy-templates.version>${groovy.version}</groovy-templates.version>
 		<groovy-xml.version>${groovy.version}</groovy-xml.version>
 		<ivy.version>2.4.0</ivy.version>
 		<gpars.version>1.2.1</gpars.version>
@@ -133,17 +133,17 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<!-- NB: Useful for template support. -->
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-templates</artifactId>
-			<version>${groovy-templates.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<!-- NB: Simple UI Building in scripts. -->
 			<groupId>org.codehaus.groovy</groupId>
   			<artifactId>groovy-swing</artifactId>
 			<version>${groovy-swing.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<!-- NB: Useful for template support. -->
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-templates</artifactId>
+			<version>${groovy-templates.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,13 +96,13 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<groovy.version>2.5.8</groovy.version>
+		<groovy-dateutil.version>2.5.8</groovy-dateutil.version>
 		<groovy-json.version>${groovy.version}</groovy-json.version>
 		<groovy-templates.version>${groovy.version}</groovy-templates.version>
+		<groovy-swing.version>2.5.8</groovy-swing.version>
 		<groovy-xml.version>${groovy.version}</groovy-xml.version>
 		<ivy.version>2.4.0</ivy.version>
 		<gpars.version>1.2.1</gpars.version>
-		<groovy-swing.version>2.5.8</groovy-swing.version>
-		<groovy-dateutil.version>2.5.8</groovy-dateutil.version>
 	</properties>
 
 	<dependencies>
@@ -119,6 +119,13 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<version>${groovy.version}</version>
 		</dependency>
 		<dependency>
+			<!-- NB: As per Groovy 2.5 must be explicitely included. -->
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-dateutil</artifactId>
+			<version>${groovy-dateutil.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<!-- NB: Useful for JSON support. -->
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-json</artifactId>
@@ -130,6 +137,13 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-templates</artifactId>
 			<version>${groovy-templates.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<!-- NB: Simple UI Building in scripts. -->
+			<groupId>org.codehaus.groovy</groupId>
+  			<artifactId>groovy-swing</artifactId>
+			<version>${groovy-swing.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -151,19 +165,6 @@ Wisconsin-Madison.</license.copyrightOwners>
 			<groupId>org.codehaus.gpars</groupId>
 			<artifactId>gpars</artifactId>
 			<version>${gpars.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<!-- NB: Simple UI Building in scripts. -->
-			<groupId>org.codehaus.groovy</groupId>
-  			<artifactId>groovy-swing</artifactId>
-			<version>${groovy-swing.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy-dateutil</artifactId>
-			<version>${groovy-dateutil.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 


### PR DESCRIPTION
Hello, 

It has already happened a few times that I could benefit from having Groovy 2.5 for some scripts. 

I've also used Groovy-Swing successfully to build simple UIs in scripts rather than going the Plugin/Command way. 

Overall I think these could be interesting for more people, Swing being very optional al this point ( I can include it myself ), But Groovy 2.5 would be really nice to have :)